### PR TITLE
Add new person from selector modal

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -685,6 +685,7 @@
   "create_new": "CREATE NEW",
   "create_new_person": "Create new person",
   "create_new_person_hint": "Assign selected assets to a new person",
+  "create_person_with_name": "Create person '{name}'",
   "create_new_user": "Create new user",
   "create_shared_album_page_share_add_assets": "ADD ASSETS",
   "create_shared_album_page_share_select_photos": "Select Photos",


### PR DESCRIPTION
```
## Description

This PR introduces the ability to create a new person directly from the face editor modal when manually tagging faces.

Previously, if a user typed a name that didn't exist, they had no option to create that person within the modal, requiring them to exit, create the person elsewhere, and then return. This change streamlines the workflow by adding a "Create person '[name]'" button that appears when the typed name does not match any existing person. Clicking this button creates the new person and automatically assigns them to the selected face.

Fixes #

## How Has This Been Tested?

- [x] **Manual Test:**
    1.  Open any asset in the photo viewing mode.
    2.  Click on a detected face (or manually draw a box) to open the face editor.
    3.  In the search input, type a name that does not correspond to any existing person in the system (e.g., "New Person Test").
    4.  Verify that a button labeled "Create person 'New Person Test'" appears below the "No people found" message.
    5.  Click the "Create person 'New Person Test'" button.
    6.  Verify that the new person is created and the face is automatically tagged with this new person.
    7.  Verify that the newly created person now appears in the list of available people in the face editor.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
![image](https://github.com/immich-app/Immich/assets/12345678/abcdefgh-ijkl-mnop-qrst-uvwxyz123456)

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
```