### PR TITLE
Fix route ordering for tag deletion

### DIFF
--- a/server/src/controllers/tag.controller.ts
+++ b/server/src/controllers/tag.controller.ts
@@ -56,6 +56,13 @@ export class TagController {
     return this.service.update(auth, id, dto);
   }
 
+  @Delete('empty')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Authenticated({ permission: Permission.TAG_DELETE })
+  deleteEmptyTags(@Auth() auth: AuthDto): Promise<void> {
+    return this.service.deleteEmptyTags(auth);
+  }
+
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   @Authenticated({ permission: Permission.TAG_DELETE })
@@ -81,12 +88,5 @@ export class TagController {
     @Param() { id }: UUIDParamDto,
   ): Promise<BulkIdResponseDto[]> {
     return this.service.removeAssets(auth, id, dto);
-  }
-
-  @Delete('empty')
-  @HttpCode(HttpStatus.NO_CONTENT)
-  @Authenticated({ permission: Permission.TAG_DELETE })
-  deleteEmptyTags(@Auth() auth: AuthDto): Promise<void> {
-    return this.service.deleteEmptyTags(auth);
   }
 }


### PR DESCRIPTION
%23%23 Description

This PR fixes a bug where the `DELETE /api/tags/empty` endpoint was incorrectly placed after the `DELETE /api/tags/:id` endpoint in `server/src/controllers/tag.controller.ts`.

This misplacement caused requests to `DELETE /api/tags/empty` to be routed to the `:id` handler, leading to "empty" being parsed as an ID and potentially causing UUID validation errors.

The fix involves reordering the routes to ensure the more specific `DELETE /api/tags/empty` route is defined before the parameterized `DELETE /api/tags/:id` route, adhering to standard routing principles.

Fixes %23 (issue)

%23%23 How Has This Been Tested%3F

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

%23%23 Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)