### PR TITLE
Fix authentication for delete empty tags

### DIFF
--- a/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -101,6 +101,7 @@
         headers: {
           'Content-Type': 'application/json',
         },
+        credentials: 'same-origin',
       });
 
       if (!response.ok) {


### PR DESCRIPTION
```
%23%23 Description

The direct `fetch` call to `DELETE /api/tags/empty` was missing authentication, leading to a 401 Unauthorized error. This occurred because the API endpoint requires `Permission.TAG_DELETE` and the request was not sending the necessary authentication cookies.

This PR resolves the issue by adding `credentials: 'same-origin'` to the `fetch` options. This ensures that the browser sends the authentication cookies with the request, allowing the API call to be properly authorized.

Fixes %23 (issue)

%23%23 How Has This Been Tested%3F

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
%23%23 API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

%23%23 Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
```