### PR TITLE
Fix unreachable code in handleDeleteEmptyTags

### DIFF
--- a/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -110,14 +110,8 @@
       // Refresh the tags list
       tags = await getAllTags();
       
-      // Navigate to root if current tag was deleted
-      if (tag.path.length > 0) {
-        // Check if current tag still exists
-        const currentTag = tags.find(t => t.id === tag.id);
-        if (!currentTag) {
-          await navigateToView('');
-        }
-      }
+      // No navigation needed since we're already at the root level
+      // (this function is only called when tag.path.length === 0)
     } catch (error) {
       console.error('Error deleting empty tags:', error);
       // You might want to show an error notification here


### PR DESCRIPTION
```
%23%23 Description

Fixes an issue in `handleDeleteEmptyTags` where unreachable navigation logic was present. The button to trigger this function is only shown at the root level (`tag.path.length === 0`), but the function contained a navigation block requiring `tag.path.length > 0`. This block was unreachable and also included an unsafe `tag.id` access.

The change removes this unreachable code and adds a clarifying comment, ensuring the function correctly handles empty tag deletion without unnecessary navigation or potential runtime errors.

Fixes %23 (issue)

%23%23 How Has This Been Tested%3F

- [ ] Manually verified that the "Delete Empty Tags" button still functions correctly (deletes empty tags and refreshes the list) from the root tag view.
- [ ] Confirmed no console errors related to `handleDeleteEmptyTags` or navigation.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

%23%23 Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
```